### PR TITLE
Remove last , from quiz correct responses

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -194,7 +194,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/edu/emory/diabetes/education/presentation/AnswerAdapter.kt
+++ b/app/src/main/java/edu/emory/diabetes/education/presentation/AnswerAdapter.kt
@@ -1,5 +1,6 @@
 package edu.emory.diabetes.education.presentation
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -31,8 +32,10 @@ class AnswerAdapter : ListAdapter<String, AnswerAdapter.ViewHolder>(AnswerAdapte
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        val formattedString = if(itemCount - 1 == position) getItem(position) else "${getItem(position)},"
+        holder.bind(formattedString)
     }
+
 
     inner class ViewHolder(
         private val bind: FragmentAnswerItemBinding

--- a/app/src/main/res/layout/fragment_answer_item.xml
+++ b/app/src/main/res/layout/fragment_answer_item.xml
@@ -20,7 +20,7 @@
             android:background="@drawable/shape_rectangle_white_radius_90px"
             android:paddingHorizontal="8dp"
             android:paddingVertical="16dp"
-            android:text="@{answer+','}"
+            android:text="@{answer}"
             tools:text="A" />
 
     </androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
Bug:
The quiz responses contain an extra "," at the end of the response list that is not necessary and can be confusing. For example: "C, A,"

Potential: pop() last character of string returned