### PR TITLE
Remove signing config from gradle and convert to env variables

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,10 +21,21 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    signingConfigs {
+        release {
+            storeFile file("PATH_TO_KEYSTORE_FILE")
+            storePassword System.getenv("APP_HATCHERY_STORE_PASSWORD")
+            keyAlias "key0"
+            keyPassword System.getenv("APP_HATCHERY_KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
     compileOptions {


### PR DESCRIPTION
Updated build.gradle

For the storeFile in the build.gradle(app) under the signingConfigs specify the path where the keystore file is located in your local machine for example:
```
{
storeFile file("C:\folder\folder\keystore.jsk")
}
```