### PR TITLE
Preserve answer on back navigation in Insulin for high blood sugar

### DIFF
--- a/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinCalculatorFragment.kt
+++ b/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinCalculatorFragment.kt
@@ -2,6 +2,7 @@ package edu.emory.diabetes.education.presentation.fragments.calculator.newcalcul
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import edu.emory.diabetes.education.R
 import edu.emory.diabetes.education.databinding.FragmentCalculatorInsulinBinding
@@ -9,10 +10,12 @@ import edu.emory.diabetes.education.presentation.BaseFragment
 import edu.emory.diabetes.education.presentation.fragments.calculator.CalculatorUtils
 
 class InsulinCalculatorFragment: BaseFragment(R.layout.fragment_calculator_insulin) {
+    val viewModel: InsulinCalculatorViewModel by activityViewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         with(FragmentCalculatorInsulinBinding.bind(view)) {
             navAdapterSetUp(this)
+            viewModel.clearData()
         }
     }
 

--- a/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinCalculatorViewModel.kt
+++ b/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinCalculatorViewModel.kt
@@ -1,0 +1,19 @@
+package edu.emory.diabetes.education.presentation.fragments.calculator.newcalculator
+
+import androidx.lifecycle.ViewModel
+
+class InsulinCalculatorViewModel: ViewModel() {
+    var totalCarbs: String = ""
+    var carbRatio: String = ""
+    var correctionFactor: String = ""
+    var bloodSugar: String = ""
+    var targetBloodSugar: String = ""
+
+    fun clearData() {
+        totalCarbs = ""
+        carbRatio = ""
+        correctionFactor = ""
+        bloodSugar = ""
+        targetBloodSugar = ""
+    }
+}

--- a/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinForFoodFragment.kt
+++ b/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinForFoodFragment.kt
@@ -18,6 +18,8 @@ import androidx.core.content.ContextCompat.getSystemService
 import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.toWindowInsetsCompat
 import androidx.core.view.isGone
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.internal.ViewUtils.dpToPx
@@ -28,7 +30,7 @@ import sdk.pendo.io.Pendo
 
 class InsulinForFoodFragment : BaseFragment(R.layout.fragment_insulin_for_food) {
     private val args: InsulinForFoodFragmentArgs by navArgs()
-
+    val viewModel: InsulinCalculatorViewModel by activityViewModels()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         with(FragmentInsulinForFoodBinding.bind(view)) {
             val sectionId = args.id

--- a/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinForHbsFragment.kt
+++ b/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/InsulinForHbsFragment.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,6 +19,8 @@ import android.widget.EditText
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import edu.emory.diabetes.education.R
 import edu.emory.diabetes.education.databinding.FragmentInsulinForHbsBinding
 import edu.emory.diabetes.education.presentation.BaseFragment
@@ -27,6 +30,7 @@ import sdk.pendo.io.Pendo
 
 class InsulinForHbsFragment : BaseFragment(R.layout.fragment_insulin_for_hbs) {
     private val args: InsulinForHbsFragmentArgs by navArgs()
+    val viewModel: InsulinCalculatorViewModel by activityViewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         with(FragmentInsulinForHbsBinding.bind(view)) {
@@ -97,6 +101,10 @@ class InsulinForHbsFragment : BaseFragment(R.layout.fragment_insulin_for_hbs) {
                     //hide keyboard
                     val inputMethodManager = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
                     inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
+                    //passing data to viewModel
+                    viewModel.correctionFactor = correctionFactor.text.toString()
+                    viewModel.bloodSugar = bloodSugarNew.text.toString()
+                    viewModel.targetBloodSugar = targetBloodSugar.text.toString()
                     //pendo tracking
                     val properties = hashMapOf<String, Any>()
                     properties["correction_factor"] = correctionFactor.text.toString()
@@ -120,6 +128,11 @@ class InsulinForHbsFragment : BaseFragment(R.layout.fragment_insulin_for_hbs) {
                     handleEmptyFields(this)
                 }
             }
+
+            correctionFactor.setText(viewModel.correctionFactor)
+            bloodSugarNew.setText(viewModel.bloodSugar)
+            targetBloodSugar.setText(viewModel.targetBloodSugar)
+
             val inputMethodManager = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
             bloodSugarNew.setOnFocusChangeListener { _, hasFocus ->
                 if (hasFocus) {

--- a/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/TotalInsulinFragment.kt
+++ b/app/src/main/java/edu/emory/diabetes/education/presentation/fragments/calculator/newcalculator/TotalInsulinFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.view.animation.AnimationUtils
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -21,6 +22,7 @@ import java.text.DecimalFormat
 
 class TotalInsulinFragment : BaseFragment(R.layout.fragment_total_insulin) {
     private val args: TotalInsulinFragmentArgs by navArgs()
+    val viewModel: InsulinCalculatorViewModel by activityViewModels()
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         with(FragmentTotalInsulinBinding.bind(view)) {
             // nav arguments
@@ -71,6 +73,7 @@ class TotalInsulinFragment : BaseFragment(R.layout.fragment_total_insulin) {
 
             //new calculator button
             newCalculator.setOnClickListener {
+                viewModel.clearData()
                 TotalInsulinFragmentDirections
                 findNavController().popBackStack(R.id.insulinCalculatorFragment, false)
             }


### PR DESCRIPTION
- added a viewModel class that holds the edit textFields data so that when a user moves back in the calculator the data is still there and it is cleared when they move to the Main calculator page or click on the new calculation button